### PR TITLE
XOR example 2

### DIFF
--- a/TOPICS/Bitwise_XOR.ipynb
+++ b/TOPICS/Bitwise_XOR.ipynb
@@ -18,7 +18,9 @@
       "cell_type": "markdown",
       "source": [
         "Useful links:\n",
-        "- Binary to Decimal or number converter: https://www.rapidtables.com/convert/number/binary-to-decimal.html"
+        "- Binary to Decimal or number converter: https://www.rapidtables.com/convert/number/binary-to-decimal.html\n",
+        "\n",
+        "- https://www.geeksforgeeks.org/tag/xor/\n"
       ],
       "metadata": {
         "id": "uWqkz0R3Q7eB"
@@ -64,7 +66,7 @@
         "id": "-6HKlCyPQKap",
         "outputId": "8e24a5c6-c125-4558-ff6c-45e37c67f11d"
       },
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -80,7 +82,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -146,7 +148,7 @@
         "id": "nm1kUfMmNC6E",
         "outputId": "d89c8e5e-b621-46ed-9af2-6d784279d7d9"
       },
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -172,7 +174,7 @@
         "id": "f_vHQlLINvZC",
         "outputId": "f14df6fc-a175-4759-da95-e6943381052f"
       },
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -187,13 +189,119 @@
       ]
     },
     {
-      "cell_type": "code",
-      "source": [],
+      "cell_type": "markdown",
+      "source": [
+        "## Q 2. Find bitwise XOR of all triplets formed from given three Arrays.\n",
+        "\n",
+        " https://www.geeksforgeeks.org/find-bitwise-xor-of-all-triplets-formed-from-given-three-arrays/"
+      ],
       "metadata": {
-        "id": "ChTI0ncINw7n"
+        "id": "9LcuVTykZHHU"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "## V1.2\n",
+        "\"\"\"\n",
+        "Time-complexity: O(N*M*P)\n",
+        "where, N, M, and P are lengths of arr1, arr2, and arr3\n",
+        "\"\"\"\n",
+        "T = int(input())\n",
+        "\n",
+        "for _ in range(T):\n",
+        "  Arr1 = list(map(int, input().split()))\n",
+        "  Arr2 = list(map(int, input().split()))\n",
+        "  Arr3 = list(map(int, input().split()))\n",
+        "\n",
+        "  N = len(Arr1)\n",
+        "  M = len(Arr2)\n",
+        "  P = len(Arr3)\n",
+        "  #Arr_triplet = []\n",
+        "  e_xor = 0\n",
+        "  ee_xor = 0\n",
+        "  for i in Arr1:\n",
+        "    for j in Arr2:\n",
+        "      for k in Arr3:\n",
+        "        #Arr_triplet.append(list([i,j,k]))\n",
+        "        e_xor = (i^j)^k  # XOR of each new combinaton of triplet\n",
+        "        ee_xor = ee_xor^e_xor # Overall XOR among each pair of triplet list\n",
+        "  print(ee_xor)\n",
+        "\n",
+        "  #print(Arr_triplet)"
+      ],
+      "metadata": {
+        "id": "ChTI0ncINw7n",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "166a49c6-d91a-459b-f5a6-d5ad9d743f12"
       },
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "1\n",
+            "3\n",
+            "4 2 3\n",
+            "1\n",
+            "7\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(len(Arr_triplet))\n",
+        "#len(Arr_triplet[0])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "6bw7vYNUrmyw",
+        "outputId": "499ff839-3f1d-4c6d-8b12-b13d494708bd"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "12\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Arr_triplet_final=[]\n",
+        "# for e in Arr_triplet:\n",
+        "#   if len(e)==3:\n",
+        "#     Arr_triplet_final.append(e)\n",
+        "# print(len(Arr_triplet_final))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "3ITAUPJmro95",
+        "outputId": "a99347a2-5397-4a9f-8226-7d1045d34901"
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "12\n"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Given three arrays arr1[], arr2[], and arr3[] consisting of non-negative integers. The task is to find the bitwise XOR of the XOR of all possible triplets that are formed by taking one element from each array.

Examples:

Input: arr1[] = {2, 3, 1}, arr2[] = {2, 4}, arr3[] = {3, 5} Output: 0
Explanation: All possible triplets are (2, 2, 3), (2, 2, 5), (2, 4, 3), (2, 4, 5), (3, 2, 3), (3, 2, 5), (3, 4, 3), (3, 4, 5), (1, 2, 3), (1, 2, 5), (1, 4, 3), (1, 4, 5). Bitwise XOR of all possible triplets are =(2^2^3) ^ (2^2^5) ^ (2^4^3) ^ (2^4^5) ^ (3^2^3) ^ (3^2^5) ^ (3^4^3) ^ (3^4^5) ^ (1^2^3) ^ (1^2^5) ^ (1^4^3) ^ (1^4^5) = 0

Input:  arr1[] = {1}, arr2[] = {3}, arr3[] = {4, 2, 3} Output:7
Explanation: All possible triplets are (1, 3, 4), (1, 3, 2), (1, 3, 3) Bitwise XOR of all possible triplets are =  (1^3^4) ^ (1^3^2) ^ (1^3^3) =7